### PR TITLE
Bounding Spheres

### DIFF
--- a/src/main/scala/Joint.scala
+++ b/src/main/scala/Joint.scala
@@ -32,7 +32,62 @@ object Joint {
     val n = DenseVector[Double](normalVec._1, normalVec._2, normalVec._3)
     -(n dot w)/linalg.norm(n)
   }
+
+  private def applyTolerance(d: Double): Double =
+    if (math.abs(d) >= EPSILON) d else 0.0
+
+  /**
+   * Find a bounding sphere for a non-persistent joint. This function is not
+   * intended for use with persistent joints.
+   * @param normalVec The normal vector of the plane in which the joint lies
+   * @param distance The distance of the joint's plane from its local origin
+   * @param centerX The x coordinate of the joint's center
+   * @param centerY The y coordinate of the joint's center
+   * @param centerZ The z coordinate of the joint's center
+   * @param faces A sequence of faces specifying the joint's shape
+   * @return A pair where the first element is a triple giving the center of
+   *         the bounding sphere and the second element is the radius of the
+   *         bounding sphere.
+   */
+  private def findBoundingSphere(normalVec: (Double,Double,Double), distance: Double, centerX: Double,
+      centerY: Double, centerZ: Double, faces: Seq[((Double,Double,Double),Double)]):
+      ((Double,Double,Double), Double) = {
+    val basisVectors = Array(
+      Array[Double](1.0, 0.0, 0.0),
+      Array[Double](0.0, 1.0, 0.0),
+      Array[Double](0.0, 0.0, 1.0),
+      Array[Double](-1.0, 0.0, 0.0),
+      Array[Double](0.0, -1.0, 0.0),
+      Array[Double](0.0, 0.0, -1.0)
+    )
+
+    val maxCoordinates = basisVectors.map { v =>
+      val linProg = new LinearProgram(3)
+      linProg.setObjFun(v.toArray, LinearProgram.MAX)
+      val jointCoeffs = Array[Double](normalVec._1, normalVec._2, normalVec._3).map(applyTolerance)
+      val jointRhs = applyTolerance(distance)
+      linProg.addConstraint(jointCoeffs, LinearProgram.LE, jointRhs)
+
+      faces foreach { face =>
+        val (a,b,c) = face._1
+        val d = face._2
+        val coeffs = Array[Double](a, b, c).map(applyTolerance)
+        val rhs = applyTolerance(d)
+        linProg.addConstraint(coeffs, LinearProgram.LE, rhs)
+      }
+      linProg.solve().get._2
+    }
+
+    val pairedCoords = maxCoordinates.take(3).zip(maxCoordinates.takeRight(3))
+    val center = pairedCoords.map { case (x,y) => 0.5 * (x+y) }
+    val diffVector = pairedCoords.map { case (x,y) => x - y }
+    val radius = 0.5 * linalg.norm(DenseVector[Double](diffVector))
+
+    // Shift from Joint local coordinates to global coordinates
+    ((center(0) + centerX, center(1) + centerY, center(2) + centerZ), radius)
+  }
 }
+
 /**
   * A simple data structure to represent a joint.
   * @constructor Create a new joint.
@@ -47,14 +102,25 @@ object Joint {
   * @param shape A list of lines specifying the shape of the joint. Each item is a
   * 3-tuple. The first two items specify the line, while the last gives the distance
   * of the line from the joint's center in the local coordinate system.
+  * @param boundingSphereParam An optional parameter that can be used to specify the bounding
+  *                            sphere for the joint, if it is known. This prevents an expensive
+  *                            recalculation of the bounding sphere.
   */
 case class Joint(normalVec: (Double, Double, Double), localOrigin: (Double, Double, Double),
                  center: (Double, Double, Double), dipAngle: Double, dipDirection: Double, phi: Double,
-                 cohesion: Double, shape: Seq[((Double, Double, Double),Double)]) {
+                 cohesion: Double, shape: Seq[((Double, Double, Double),Double)],
+                 boundingSphereParam: Option[((Double,Double,Double),Double)]=null) {
   val (a, b, c) = normalVec
   val (centerX, centerY, centerZ) = center
   val d = Joint.findDistance(normalVec, localOrigin, center)
   val (localX, localY, localZ) = localOrigin
+  val boundingSphere = boundingSphereParam match {
+    case null => shape match {
+      case Nil => None
+      case _ => Some(Joint.findBoundingSphere((a, b, c), d, centerX, centerY, centerZ, shape))
+    }
+    case bs => bs
+  }
 
   /** Converts lines defining shape of joint from local to global coordinates
     * @return A seq of pairs, each representing a plane that specifies a boundary of the
@@ -92,6 +158,7 @@ case class Joint(normalVec: (Double, Double, Double), localOrigin: (Double, Doub
     * @return Distance relative to block origin (new local origin)
     */
   def updateJoint(blockOrigin: (Double, Double,Double)): Joint = {
-    Joint((a, b, c), blockOrigin, (centerX, centerY, centerZ), dipAngle, dipDirection, phi, cohesion, shape)
+    Joint((a, b, c), blockOrigin, (centerX, centerY, centerZ), dipAngle, dipDirection, phi, cohesion,
+          shape, boundingSphere)
   }
 }

--- a/src/main/scala/Joint.scala
+++ b/src/main/scala/Joint.scala
@@ -14,7 +14,7 @@ object Joint {
    * @return
    */
   private def findDistance(normalVec: (Double, Double, Double), localOrigin: (Double, Double, Double),
-                            center: (Double, Double, Double)) = {
+                            center: (Double, Double, Double)): Double = {
     val w = DenseVector.zeros[Double](3)
     if (math.abs(normalVec._3) >= EPSILON) {
       w(0) = localOrigin._1

--- a/src/test/scala/BlockSpec.scala
+++ b/src/test/scala/BlockSpec.scala
@@ -1,4 +1,4 @@
-import breeze.numerics.{pow, sqrt}
+import math.sqrt
 import org.scalatest._
 import edu.berkeley.ce.rockslicing.{Face, Block, Joint, Delaunay}
 
@@ -277,7 +277,7 @@ class BlockSpec extends FunSuite {
     val face1 = Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0)
     val face2 = Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0)
     val face3 = Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0)
-    val face4 = Face((1/math.sqrt(2.0), 1/math.sqrt(2.0), 0.0), 1/math.sqrt(2.0), phi=0, cohesion=0)
+    val face4 = Face((1/sqrt(2.0), 1/sqrt(2.0), 0.0), 1/sqrt(2.0), phi=0, cohesion=0)
     val block = Block((1.0, 1.0, 1.0), List(face1, face2, face3, face4))
 
     val vertices = block.findVertices

--- a/src/test/scala/JointSpec.scala
+++ b/src/test/scala/JointSpec.scala
@@ -1,4 +1,4 @@
-import breeze.numerics.sqrt
+import math.sqrt
 import org.scalatest._
 import edu.berkeley.ce.rockslicing.Joint
 
@@ -46,10 +46,10 @@ class JointSpec extends FunSuite {
     val joint = Joint((0.0, 0.0, 1.0), localOrigin=(0.0,0.0,-1.0), center=(0.0, 0.0, 0.0), dipAngle=0,
                       dipDirection=math.Pi/4.0, phi=0, cohesion=0, shape=boundaries)
     val newBoundaries: List[((Double,Double,Double), Double)] =
-      List(((math.sqrt(2)/2.0, -math.sqrt(2)/2.0, 0.0), 1.0),
-           ((-math.sqrt(2)/2.0, math.sqrt(2)/2.0, 0.0), 0.0),
-           ((math.sqrt(2)/2.0, math.sqrt(2)/2.0, 0.0), 1.0),
-           ((-math.sqrt(2)/2.0, -math.sqrt(2)/2.0, 0.0), 0.0))
+      List(((sqrt(2)/2.0, -sqrt(2)/2.0, 0.0), 1.0),
+           ((-sqrt(2)/2.0, sqrt(2)/2.0, 0.0), 0.0),
+           ((sqrt(2)/2.0, sqrt(2)/2.0, 0.0), 1.0),
+           ((-sqrt(2)/2.0, -sqrt(2)/2.0, 0.0), 0.0))
     assert(totalDifference(joint.globalCoordinates, newBoundaries) <= EPSILON)
   }
 
@@ -57,10 +57,10 @@ class JointSpec extends FunSuite {
     val joint = Joint((0.0, 0.0, 1.0), localOrigin=(0.0,0.0,2.0), center=(1.0, 2.0, 3.0), dipAngle=0,
                       dipDirection=math.Pi/4.0, phi=0, cohesion=0, shape=boundaries)
     val newBoundaries: List[((Double,Double,Double), Double)] =
-      List(((math.sqrt(2)/2.0, -math.sqrt(2)/2.0, 0.0), 1 - math.sqrt(2)/2.0),
-           ((-math.sqrt(2)/2.0, math.sqrt(2)/2.0, 0.0), math.sqrt(2)/2.0),
-           ((math.sqrt(2)/2.0, math.sqrt(2)/2.0, 0.0), 1 + 3*math.sqrt(2)/2.0),
-           ((-math.sqrt(2)/2.0, -math.sqrt(2)/2.0, 0.0), -3*math.sqrt(2)/2.0))
+      List(((sqrt(2)/2.0, -sqrt(2)/2.0, 0.0), 1 - sqrt(2)/2.0),
+           ((-sqrt(2)/2.0, sqrt(2)/2.0, 0.0), sqrt(2)/2.0),
+           ((sqrt(2)/2.0, sqrt(2)/2.0, 0.0), 1 + 3*sqrt(2)/2.0),
+           ((-sqrt(2)/2.0, -sqrt(2)/2.0, 0.0), -3*sqrt(2)/2.0))
     assert(totalDifference(joint.globalCoordinates, newBoundaries) <= EPSILON)
   }
 


### PR DESCRIPTION
This incorporates the bounding sphere technique described in Boon et. al. 2015 into our code base. Simple bounding spheres are computed for rock blocks and for non-persistent joints. These can then be used to avoid the expensive process of solving linear programs for many intersection checks.
