### PR TITLE
Convex hull

### DIFF
--- a/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
+++ b/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
@@ -75,7 +75,7 @@ object Block {
       val faceNormal = DenseVector[Double](face.a, face.b, face.c)
       // If distance is negative, point lies within block - planes will not intersect within block
       // since block is convex
-      (pointVector dot faceNormal - face.d) < NumericUtils.EPSILON
+      ((pointVector dot faceNormal) - face.d) < NumericUtils.EPSILON
     }
     !distanceChecks.contains(false)
   }

--- a/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
+++ b/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
@@ -277,9 +277,9 @@ case class Block(center: (Double,Double,Double), faces: Seq[Face]) {
               val p_vect = A_matx \ b_vect
               // Check if point is within block, otherwise discard it
               if (Block.pointInBlock((p_vect(0), p_vect(1), p_vect(2)), faces)) {
-                Some((NumericUtils.roundToTolerance(p_vect(0) + centerX),
-                      NumericUtils.roundToTolerance(p_vect(1) + centerY),
-                      NumericUtils.roundToTolerance(p_vect(2) + centerZ)))
+                Some((p_vect(0) + centerX,
+                      p_vect(1) + centerY,
+                      p_vect(2) + centerZ))
               } else None
             } else None
           }

--- a/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
+++ b/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
@@ -70,15 +70,13 @@ object Block {
     * @return True if the point is outside the block, false otherwise
     */
   private def pointOutsideBlock(point: (Double, Double, Double), faces: Seq[Face]): Boolean = {
-    val distanceChecks = faces map { face =>
+    faces exists { face =>
       val pointVector = DenseVector[Double](point._1, point._2, point._3)
       val faceNormal = DenseVector[Double](face.a, face.b, face.c)
       // If distance is negative, point lies within block - planes will not intersect within block
       // since block is convex
-      ((pointVector dot faceNormal) - face.d) < NumericUtils.EPSILON
+      ((pointVector dot faceNormal) - face.d) > NumericUtils.EPSILON
     }
-    distanceChecks.exists(_ == false)
-    // !distanceChecks.contains(false)
   }
 
   /**

--- a/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
+++ b/src/main/scala/edu/berkeley/ce/rockslicing/Block.scala
@@ -64,20 +64,21 @@ object Block {
   }
 
   /** 
-    * Determines whether the input point is within the input block
+    * Determines whether the input point is outside the input block
     * @param point The point as a tuple
     * @param block The block that the point is being checked agains
-    * @return True if the point is within the block, false otherwise
+    * @return True if the point is outside the block, false otherwise
     */
-  private def pointInBlock(point: (Double, Double, Double), faces: Seq[Face]): Boolean = {
-    val distanceChecks = faces map { case face =>
+  private def pointOutsideBlock(point: (Double, Double, Double), faces: Seq[Face]): Boolean = {
+    val distanceChecks = faces map { face =>
       val pointVector = DenseVector[Double](point._1, point._2, point._3)
       val faceNormal = DenseVector[Double](face.a, face.b, face.c)
       // If distance is negative, point lies within block - planes will not intersect within block
       // since block is convex
       ((pointVector dot faceNormal) - face.d) < NumericUtils.EPSILON
     }
-    !distanceChecks.contains(false)
+    distanceChecks.exists(_ == false)
+    // !distanceChecks.contains(false)
   }
 
   /**
@@ -276,7 +277,7 @@ case class Block(center: (Double,Double,Double), faces: Seq[Face]) {
               A_matx(2, ::) := n3.t
               val p_vect = A_matx \ b_vect
               // Check if point is within block, otherwise discard it
-              if (Block.pointInBlock((p_vect(0), p_vect(1), p_vect(2)), faces)) {
+              if (!Block.pointOutsideBlock((p_vect(0), p_vect(1), p_vect(2)), faces)) {
                 Some((p_vect(0) + centerX,
                       p_vect(1) + centerY,
                       p_vect(2) + centerZ))

--- a/src/main/scala/edu/berkeley/ce/rockslicing/BlockVTK.scala
+++ b/src/main/scala/edu/berkeley/ce/rockslicing/BlockVTK.scala
@@ -27,7 +27,8 @@ object BlockVTK {
   private def ccwCompare(pointA: (Double, Double, Double), pointB: (Double, Double, Double),
                          center: (Double, Double, Double)): Boolean = {
     // Check that points are in the same x-y plane
-    if (math.abs(pointA._3 - pointB._3) > NumericUtils.EPSILON) {
+    if (math.abs(NumericUtils.roundToTolerance(pointA._3, 5) -
+        NumericUtils.roundToTolerance(pointB._3, 5)) > NumericUtils.EPSILON) {
       throw new IllegalArgumentException("ERROR: Input to BlockVTK.ccwCompare: "+
                                          "Input points are not in the same plane")
     }    

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockSpec.scala
@@ -312,9 +312,9 @@ class BlockSpec extends FunSuite {
   }
 
   test("The points of intersection between the four planes should (0.0, 0.0, 0.0) & (0.0, 5.0, 0.0)") {
-    val face1 = Face((1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0)
-    val face2 = Face((0.0, 1.0, 0.0), 0.0, phi=0, cohesion=0)
-    val face3 = Face((0.0, 0.0, 1.0), 0.0, phi=0, cohesion=0)
+    val face1 = Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0)
+    val face2 = Face((0.0, -1.0, 0.0), 0.0, phi=0, cohesion=0)
+    val face3 = Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0)
     val face4 = Face((0.0, 1.0, 0.0), 5.0, phi=0, cohesion=0)
     val block = Block((0.0, 0.0, 0.0), List(face1, face2, face3, face4))
     val face1Verts = List((0.0, 0.0, 0.0), (0.0, 5.0, 0.0))
@@ -366,7 +366,7 @@ class BlockSpec extends FunSuite {
     val face1 = Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0)
     val face2 = Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0)
     val face3 = Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0)
-    val face4 = Face((1/sqrt(2.0), 1/sqrt(2.0), 0.0), 1/sqrt(2.0), phi=0, cohesion=0)
+    val face4 = Face((-1/sqrt(2.0), -1/sqrt(2.0), 0.0), 1/sqrt(2.0), phi=0, cohesion=0)
     val block = Block((1.0, 1.0, 1.0), List(face1, face2, face3, face4))
 
     val vertices = block.findVertices

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
@@ -14,6 +14,8 @@ class BlockVTKSpec extends FunSuite {
   )
   val unitCube = Block((0.0, 0.0, 0.0), boundingFaces)
 
+  // Seven sided block
+  val distance = 1.0 // Should be greater than 1/sqrt(2.0) for intercept calcs to hold
   val boundingFaces2 = List(
     Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0), // -x <= 0
     Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0),  // x <= 1
@@ -21,10 +23,11 @@ class BlockVTKSpec extends FunSuite {
     Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0),  // y <= 1
     Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0), // -z <= 0
     Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0),  // z <= 1
-    Face((0.707106781187, 0.707106781187, 0.0), 0.707106781187 - 0.5, phi=0, cohesion=0) // sqrt(2)*x + sqrt(2)*y <= 1
+    Face((0.707106781187, 0.707106781187, 0.0), distance, phi=0, cohesion=0) // sqrt(2)*x + sqrt(2)*y <= 1
   )
   val sevenSidedBlock = Block((0.0, 0.0, 0.0), boundingFaces2)
 
+  // Faces for unit Cube
   val face1 = Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0)
   val face2 = Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0)
   val face3 = Face((0.0, -1.0, 0.0), 0.0, phi=0, cohesion=0)
@@ -37,6 +40,24 @@ class BlockVTKSpec extends FunSuite {
   val face4Verts = List((0.0, 1.0, 0.0), (0.0, 1.0, 1.0), (1.0, 1.0, 1.0), (1.0, 1.0, 0.0))
   val face5Verts = List((1.0, 1.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0))
   val face6Verts = List((0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 1.0))
+
+  // Faces for seven sided cube
+  val x_intercept = NumericUtils.roundToTolerance(distance - sqrt(2.0)*(sqrt(2.0) - distance))
+  val y_intercept = NumericUtils.roundToTolerance(distance - sqrt(2.0)*(sqrt(2.0) - distance))
+  val face1_s7 = Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0)
+  val face2_s7 = Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0)
+  val face3_s7 = Face((0.0, -1.0, 0.0), 0.0, phi=0, cohesion=0)
+  val face4_s7 = Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0)
+  val face5_s7 = Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0)
+  val face6_s7 = Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0)
+  val face7_s7 = Face((0.707106781187, 0.707106781187, 0.0), 1.0, phi=0, cohesion=0)
+  val face1Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 1.0))
+  val face2Verts_s7 = List((1.0, y_intercept, 1.0), (1.0, 0.0, 1.0), (1.0, 0.0, 0.0), (1.0, y_intercept, 0.0))
+  val face3Verts_s7 = List((0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 1.0))
+  val face4Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 1.0, 1.0), (x_intercept, 1.0, 1.0), (x_intercept, 1.0, 0.0))
+  val face5Verts_s7 = List((1.0, y_intercept, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0), (x_intercept, 1.0, 0.0))
+  val face6Verts_s7 = List((x_intercept, 1.0, 1.0), (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, y_intercept, 1.0))
+  val face7Verts_s7 = List((x_intercept, 1.0, 1.0), (1.0, y_intercept, 1.0), (1.0, y_intercept, 0.0), (x_intercept, 1.0, 0.0))
 
   private def doubleListElementDiff(list1: Seq[Double], list2: Seq[Double]): Seq[Double] = {
     assert(list1.length == list2.length)
@@ -61,24 +82,34 @@ class BlockVTKSpec extends FunSuite {
     assert(expectedVertices == vtkBlock.orientedVertices)
   }
 
-  // test("The vertices should be oriented counter-clockwise for each face (seven-sided block)") {
-  //   val expectedVertices = Map(
-  //     face1 -> face1Verts,
-  //     face2 -> face2Verts,
-  //     face3 -> face3Verts,
-  //     face4 -> face4Verts,
-  //     face5 -> face5Verts,
-  //     face6 -> face6Verts
-  //   )
-  //   val vtkBlock = BlockVTK(sevenSidedBlock)
-  //   println(vtkBlock.tupleVertices)
-  //   assert(expectedVertices == vtkBlock.orientedVertices)
-  // }
+  test("The vertices should be oriented counter-clockwise for each face (seven-sided block)") {
+    val expectedVertices = Map(
+      face1_s7 -> face1Verts_s7,
+      face2_s7 -> face2Verts_s7,
+      face3_s7 -> face3Verts_s7,
+      face4_s7 -> face4Verts_s7,
+      face5_s7 -> face5Verts_s7,
+      face6_s7 -> face6Verts_s7,
+      face7_s7 -> face7Verts_s7
+    )
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    assert(expectedVertices == vtkBlock.orientedVertices)
+  }
 
   test("List of vertices should contain only distinct vertices as tuples") {
     val vtkBlock = BlockVTK(unitCube)
     val expectedVertices = List((0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 1.0),
                                 (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0))
+    assert(expectedVertices == vtkBlock.tupleVertices)
+  }
+
+  test("List of vertices should contain only distinct vertices as tuples (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val expectedVertices = List((x_intercept, 1.0, 1.0), (1.0, y_intercept, 1.0),
+                                (1.0, y_intercept, 0.0), (x_intercept, 1.0, 0.0),
+                                (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0),
+                                (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+    println(vtkBlock.tupleVertices)
     assert(expectedVertices == vtkBlock.tupleVertices)
   }
 
@@ -90,9 +121,26 @@ class BlockVTKSpec extends FunSuite {
     assert(verticesDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
   }
 
+  test("List of tuple vertices should flatten into list of doubles (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val expectedVertices = List(x_intercept, 1.0, 1.0, 1.0, y_intercept, 1.0,
+                                1.0, y_intercept, 0.0, x_intercept, 1.0, 0.0,
+                                0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0,
+                                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+    val verticesDiff = doubleListElementDiff(expectedVertices, vtkBlock.vertices)
+    assert(verticesDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+  }
+
   test("Vertex ID's should start from 0 and go up to 7") {
     val vtkBlock = BlockVTK(unitCube)
     val expectedIDs = Seq.range(0, 8)
+    val idsDiff = intListElementDiff(expectedIDs.toSeq, vtkBlock.vertexIDs.toSeq)
+    assert(idsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+  }
+
+  test("Vertex ID's should start from 0 and go up to 9 (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val expectedIDs = Seq.range(0, 10)
     val idsDiff = intListElementDiff(expectedIDs.toSeq, vtkBlock.vertexIDs.toSeq)
     assert(idsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
   }
@@ -106,6 +154,22 @@ class BlockVTKSpec extends FunSuite {
       face4 -> List[Int](4, 0, 3, 7),
       face5 -> List[Int](7, 6, 5, 4),
       face6 -> List[Int](0, 1, 2, 3)
+    )
+    assert(faceConnectivities == vtkBlock.connectivityMap)
+  }
+
+  // CONTINUE HERE
+  test("Connectivities for each face should be in terms of vertex ID's (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val faceConnectivities = Map(
+      //fix these
+      face1_s7 -> List[Int](4, 5, 1, 0),
+      face2_s7 -> List[Int](3, 2, 6, 7),
+      face3_s7 -> List[Int](1, 5, 6, 2),
+      face4_s7 -> List[Int](4, 0, 3, 7),
+      face5_s7 -> List[Int](7, 6, 5, 4),
+      face6_s7 -> List[Int](0, 1, 2, 3),
+      face7_s7 -> List[Int](//Put some number is here)
     )
     assert(faceConnectivities == vtkBlock.connectivityMap)
   }

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
@@ -23,7 +23,7 @@ class BlockVTKSpec extends FunSuite {
     Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0),  // y <= 1
     Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0), // -z <= 0
     Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0),  // z <= 1
-    Face((0.707106781187, 0.707106781187, 0.0), distance, phi=0, cohesion=0) // sqrt(2)*x + sqrt(2)*y <= 1
+    Face((1/sqrt(2.0), 1/sqrt(2.0), 0.0), distance, phi=0, cohesion=0) // 1/sqrt(2)*x + 1/sqrt(2)*y <= 1
   )
   val sevenSidedBlock = Block((0.0, 0.0, 0.0), boundingFaces2)
 
@@ -50,7 +50,7 @@ class BlockVTKSpec extends FunSuite {
   val face4_s7 = Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0)
   val face5_s7 = Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0)
   val face6_s7 = Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0)
-  val face7_s7 = Face((0.707106781187, 0.707106781187, 0.0), 1.0, phi=0, cohesion=0)
+  val face7_s7 = Face((1/sqrt(2.0), 1/sqrt(2.0), 0.0), 1.0, phi=0, cohesion=0)
   val face1Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 1.0))
   val face2Verts_s7 = List((1.0, y_intercept, 1.0), (1.0, 0.0, 1.0), (1.0, 0.0, 0.0),
                            (1.0, y_intercept, 0.0))
@@ -103,61 +103,63 @@ class BlockVTKSpec extends FunSuite {
 
   test("List of vertices should contain only distinct vertices as tuples") {
     val vtkBlock = BlockVTK(unitCube)
-    val expectedVertices = List((0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 1.0),
+    val expectedVertices = Seq((0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, 1.0, 1.0),
                                 (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0))
     assert(expectedVertices == vtkBlock.tupleVertices)
   }
 
   test("List of vertices should contain only distinct vertices as tuples (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
-    val expectedVertices = List((x_intercept, 1.0, 1.0), (1.0, y_intercept, 1.0),
-                                (1.0, y_intercept, 0.0), (x_intercept, 1.0, 0.0),
-                                (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0),
-                                (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+    val expectedVertices = Seq((x_intercept, 1.0, 1.0), (0.0, 1.0, 1.0), 
+                                (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), 
+                                (1.0, y_intercept, 1.0), (1.0, y_intercept, 0.0),
+                                (x_intercept, 1.0, 0.0), (0.0, 1.0, 0.0),
+                                (0.0, 0.0, 0.0), (1.0, 0.0, 0.0))
     assert(expectedVertices == vtkBlock.tupleVertices)
   }
 
   test("List of tuple vertices should flatten into list of doubles") {
     val vtkBlock = BlockVTK(unitCube)
-    val expectedVertices = List(0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+    val expectedVertices = Seq(0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0,
                                 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0)
     val verticesDiff = doubleListElementDiff(expectedVertices, vtkBlock.vertices)
-    assert(verticesDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(verticesDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("List of tuple vertices should flatten into list of doubles (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
-    val expectedVertices = List(x_intercept, 1.0, 1.0, 1.0, y_intercept, 1.0,
-                                1.0, y_intercept, 0.0, x_intercept, 1.0, 0.0,
-                                0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0,
-                                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+    val expectedVertices = Seq(x_intercept, 1.0, 1.0, 0.0, 1.0, 1.0, 
+                                0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 
+                                1.0, y_intercept, 1.0, 1.0, y_intercept, 0.0,
+                                x_intercept, 1.0, 0.0, 0.0, 1.0, 0.0,
+                                0.0, 0.0, 0.0, 1.0, 0.0, 0.0)
     val verticesDiff = doubleListElementDiff(expectedVertices, vtkBlock.vertices)
-    assert(verticesDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(verticesDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Vertex ID's should start from 0 and go up to 7") {
     val vtkBlock = BlockVTK(unitCube)
-    val expectedIDs = Seq.range(0, 8)
+    val expectedIDs = 0 until 8
     val idsDiff = intListElementDiff(expectedIDs.toSeq, vtkBlock.vertexIDs.toSeq)
-    assert(idsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(idsDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Vertex ID's should start from 0 and go up to 9 (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
-    val expectedIDs = Seq.range(0, 10)
+    val expectedIDs = 0 until 10
     val idsDiff = intListElementDiff(expectedIDs.toSeq, vtkBlock.vertexIDs.toSeq)
-    assert(idsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(idsDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Connectivities for each face should be in terms of vertex ID's") {
     val vtkBlock = BlockVTK(unitCube)
     val faceConnectivities = Map(
-      face1 -> List[Int](4, 5, 1, 0),
-      face2 -> List[Int](3, 2, 6, 7),
-      face3 -> List[Int](1, 5, 6, 2),
-      face4 -> List[Int](4, 0, 3, 7),
-      face5 -> List[Int](7, 6, 5, 4),
-      face6 -> List[Int](0, 1, 2, 3)
+      face1 -> Seq[Int](4, 5, 1, 0),
+      face2 -> Seq[Int](3, 2, 6, 7),
+      face3 -> Seq[Int](1, 5, 6, 2),
+      face4 -> Seq[Int](4, 0, 3, 7),
+      face5 -> Seq[Int](7, 6, 5, 4),
+      face6 -> Seq[Int](0, 1, 2, 3)
     )
     assert(faceConnectivities == vtkBlock.connectivityMap)
   }
@@ -165,13 +167,13 @@ class BlockVTKSpec extends FunSuite {
   test("Connectivities for each face should be in terms of vertex ID's (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
     val faceConnectivities = Map(
-      face1_s7 -> List[Int](7, 8, 5, 4),
-      face2_s7 -> List[Int](1, 6, 9, 2),
-      face3_s7 -> List[Int](5, 8, 9, 6),
-      face4_s7 -> List[Int](7, 4, 0, 3),
-      face5_s7 -> List[Int](2, 9, 8, 7, 3),
-      face6_s7 -> List[Int](0, 4, 5, 6, 1),
-      face7_s7 -> List[Int](0, 1, 2, 3)
+      face1_s7 -> Seq[Int](7, 8, 2, 1),
+      face2_s7 -> Seq[Int](4, 3, 9, 5),
+      face3_s7 -> Seq[Int](2, 8, 9, 3),
+      face4_s7 -> Seq[Int](7, 1, 0, 6),
+      face5_s7 -> Seq[Int](5, 9, 8, 7, 6),
+      face6_s7 -> Seq[Int](0, 1, 2, 3, 4),
+      face7_s7 -> Seq[Int](0, 4, 5, 6)
     )
     assert(faceConnectivities == vtkBlock.connectivityMap)
   }
@@ -181,16 +183,14 @@ class BlockVTKSpec extends FunSuite {
     val faceConnectivities = Seq[Int](0, 1, 2, 3, 4, 5, 1, 0, 3, 2, 6, 7,
                                       4, 0, 3, 7, 7, 6, 5, 4, 1, 5, 6, 2)
     val connectionsDiff = intListElementDiff(faceConnectivities.toSeq, vtkBlock.connectivity.toSeq)
-    assert(connectionsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(connectionsDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Connectivity map should flatten into list of integers (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
-    val faceConnectivities = Seq[Int](0, 1, 2, 3, 0, 4, 5, 6, 1, 7, 8, 5, 4,
-                                      1, 6, 9, 2, 7, 4, 0, 3, 2, 9, 8, 7, 3,
-                                      5, 8, 9, 6)
+    val faceConnectivities = Seq[Int](0, 1, 2, 3, 4, 0, 4, 5, 6, 7, 8, 2, 1, 4, 3, 9, 5, 7, 1, 0, 6, 5, 9, 8, 7, 6, 2, 8, 9, 3)
     val connectionsDiff = intListElementDiff(faceConnectivities.toSeq, vtkBlock.connectivity.toSeq)
-    assert(connectionsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(connectionsDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Number of faces should be 6") {
@@ -205,17 +205,17 @@ class BlockVTKSpec extends FunSuite {
 
   test("Offsets should be incremented by number of vertices on each face when iterating through list of faces") {
     val vtkBlock = BlockVTK(unitCube)
-    val expectedOffsets = List(4, 8, 12, 16, 20, 24)
+    val expectedOffsets = Seq(4, 8, 12, 16, 20, 24)
     val offsetDiff = intListElementDiff(expectedOffsets, vtkBlock.offsets)
-    assert(offsetDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(offsetDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Offsets should be incremented by number of vertices on each face when iterating through list of faces "+
        "(seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
-    val expectedOffsets = List(4, 9, 13, 17, 21, 26, 30)
+    val expectedOffsets = Seq(4, 9, 13, 17, 21, 26, 30)
     val offsetDiff = intListElementDiff(expectedOffsets, vtkBlock.offsets)
-    assert(offsetDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(offsetDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Normals tuples should flatten into list of integers") {
@@ -230,14 +230,14 @@ class BlockVTKSpec extends FunSuite {
     ) 
     val normals = vtkBlock.normals
     val normalsDiff = doubleListElementDiff(expectedNormals, normals)
-    assert(normalsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(normalsDiff forall (_ < NumericUtils.EPSILON))
   }
 
   test("Normals tuples should flatten into list of integers (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
     val expectedNormals = Seq[Double](
-      face7_s7.a, face7_s7.b, face7_s7.c,
       face6_s7.a, face6_s7.b, face6_s7.c,
+      face7_s7.a, face7_s7.b, face7_s7.c,
       face1_s7.a, face1_s7.b, face1_s7.c,
       face2_s7.a, face2_s7.b, face2_s7.c,
       face4_s7.a, face4_s7.b, face4_s7.c,
@@ -246,6 +246,6 @@ class BlockVTKSpec extends FunSuite {
     ) 
     val normals = vtkBlock.normals
     val normalsDiff = doubleListElementDiff(expectedNormals, normals)
-    assert(normalsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+    assert(normalsDiff forall (_ < NumericUtils.EPSILON))
   }
 }

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
@@ -61,19 +61,19 @@ class BlockVTKSpec extends FunSuite {
     assert(expectedVertices == vtkBlock.orientedVertices)
   }
 
-  test("The vertices should be oriented counter-clockwise for each face (seven-sided block)") {
-    val expectedVertices = Map(
-      face1 -> face1Verts,
-      face2 -> face2Verts,
-      face3 -> face3Verts,
-      face4 -> face4Verts,
-      face5 -> face5Verts,
-      face6 -> face6Verts
-    )
-    val vtkBlock = BlockVTK(sevenSidedBlock)
-    println(vtkBlock.tupleVertices)
-    assert(expectedVertices == vtkBlock.orientedVertices)
-  }
+  // test("The vertices should be oriented counter-clockwise for each face (seven-sided block)") {
+  //   val expectedVertices = Map(
+  //     face1 -> face1Verts,
+  //     face2 -> face2Verts,
+  //     face3 -> face3Verts,
+  //     face4 -> face4Verts,
+  //     face5 -> face5Verts,
+  //     face6 -> face6Verts
+  //   )
+  //   val vtkBlock = BlockVTK(sevenSidedBlock)
+  //   println(vtkBlock.tupleVertices)
+  //   assert(expectedVertices == vtkBlock.orientedVertices)
+  // }
 
   test("List of vertices should contain only distinct vertices as tuples") {
     val vtkBlock = BlockVTK(unitCube)

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
@@ -52,12 +52,17 @@ class BlockVTKSpec extends FunSuite {
   val face6_s7 = Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0)
   val face7_s7 = Face((0.707106781187, 0.707106781187, 0.0), 1.0, phi=0, cohesion=0)
   val face1Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 1.0))
-  val face2Verts_s7 = List((1.0, y_intercept, 1.0), (1.0, 0.0, 1.0), (1.0, 0.0, 0.0), (1.0, y_intercept, 0.0))
+  val face2Verts_s7 = List((1.0, y_intercept, 1.0), (1.0, 0.0, 1.0), (1.0, 0.0, 0.0),
+                           (1.0, y_intercept, 0.0))
   val face3Verts_s7 = List((0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 0.0, 1.0))
-  val face4Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 1.0, 1.0), (x_intercept, 1.0, 1.0), (x_intercept, 1.0, 0.0))
-  val face5Verts_s7 = List((1.0, y_intercept, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0), (x_intercept, 1.0, 0.0))
-  val face6Verts_s7 = List((x_intercept, 1.0, 1.0), (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (1.0, y_intercept, 1.0))
-  val face7Verts_s7 = List((x_intercept, 1.0, 1.0), (1.0, y_intercept, 1.0), (1.0, y_intercept, 0.0), (x_intercept, 1.0, 0.0))
+  val face4Verts_s7 = List((0.0, 1.0, 0.0), (0.0, 1.0, 1.0), (x_intercept, 1.0, 1.0),
+                           (x_intercept, 1.0, 0.0))
+  val face5Verts_s7 = List((1.0, y_intercept, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0),
+                           (x_intercept, 1.0, 0.0))
+  val face6Verts_s7 = List((x_intercept, 1.0, 1.0), (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0),
+                           (1.0, y_intercept, 1.0))
+  val face7Verts_s7 = List((x_intercept, 1.0, 1.0), (1.0, y_intercept, 1.0), (1.0, y_intercept, 0.0),
+                           (x_intercept, 1.0, 0.0))
 
   private def doubleListElementDiff(list1: Seq[Double], list2: Seq[Double]): Seq[Double] = {
     assert(list1.length == list2.length)
@@ -109,7 +114,6 @@ class BlockVTKSpec extends FunSuite {
                                 (1.0, y_intercept, 0.0), (x_intercept, 1.0, 0.0),
                                 (0.0, 1.0, 1.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0),
                                 (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0))
-    println(vtkBlock.tupleVertices)
     assert(expectedVertices == vtkBlock.tupleVertices)
   }
 
@@ -158,18 +162,16 @@ class BlockVTKSpec extends FunSuite {
     assert(faceConnectivities == vtkBlock.connectivityMap)
   }
 
-  // CONTINUE HERE
   test("Connectivities for each face should be in terms of vertex ID's (seven-sided block)") {
     val vtkBlock = BlockVTK(sevenSidedBlock)
     val faceConnectivities = Map(
-      //fix these
-      face1_s7 -> List[Int](4, 5, 1, 0),
-      face2_s7 -> List[Int](3, 2, 6, 7),
-      face3_s7 -> List[Int](1, 5, 6, 2),
-      face4_s7 -> List[Int](4, 0, 3, 7),
-      face5_s7 -> List[Int](7, 6, 5, 4),
-      face6_s7 -> List[Int](0, 1, 2, 3),
-      face7_s7 -> List[Int](//Put some number is here)
+      face1_s7 -> List[Int](7, 8, 5, 4),
+      face2_s7 -> List[Int](1, 6, 9, 2),
+      face3_s7 -> List[Int](5, 8, 9, 6),
+      face4_s7 -> List[Int](7, 4, 0, 3),
+      face5_s7 -> List[Int](2, 9, 8, 7, 3),
+      face6_s7 -> List[Int](0, 4, 5, 6, 1),
+      face7_s7 -> List[Int](0, 1, 2, 3)
     )
     assert(faceConnectivities == vtkBlock.connectivityMap)
   }
@@ -182,14 +184,36 @@ class BlockVTKSpec extends FunSuite {
     assert(connectionsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
   }
 
+  test("Connectivity map should flatten into list of integers (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val faceConnectivities = Seq[Int](0, 1, 2, 3, 0, 4, 5, 6, 1, 7, 8, 5, 4,
+                                      1, 6, 9, 2, 7, 4, 0, 3, 2, 9, 8, 7, 3,
+                                      5, 8, 9, 6)
+    val connectionsDiff = intListElementDiff(faceConnectivities.toSeq, vtkBlock.connectivity.toSeq)
+    assert(connectionsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+  }
+
   test("Number of faces should be 6") {
     val vtkBlock = BlockVTK(unitCube)
     assert(vtkBlock.faceCount == 6)
   }
 
+  test("Number of faces should be 7 (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    assert(vtkBlock.faceCount == 7)
+  }
+
   test("Offsets should be incremented by number of vertices on each face when iterating through list of faces") {
     val vtkBlock = BlockVTK(unitCube)
     val expectedOffsets = List(4, 8, 12, 16, 20, 24)
+    val offsetDiff = intListElementDiff(expectedOffsets, vtkBlock.offsets)
+    assert(offsetDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+  }
+
+  test("Offsets should be incremented by number of vertices on each face when iterating through list of faces "+
+       "(seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val expectedOffsets = List(4, 9, 13, 17, 21, 26, 30)
     val offsetDiff = intListElementDiff(expectedOffsets, vtkBlock.offsets)
     assert(offsetDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
   }
@@ -203,6 +227,22 @@ class BlockVTKSpec extends FunSuite {
       face4.a, face4.b, face4.c,
       face5.a, face5.b, face5.c,
       face3.a, face3.b, face3.c
+    ) 
+    val normals = vtkBlock.normals
+    val normalsDiff = doubleListElementDiff(expectedNormals, normals)
+    assert(normalsDiff.filter(_ > NumericUtils.EPSILON).isEmpty)
+  }
+
+  test("Normals tuples should flatten into list of integers (seven-sided block)") {
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    val expectedNormals = Seq[Double](
+      face7_s7.a, face7_s7.b, face7_s7.c,
+      face6_s7.a, face6_s7.b, face6_s7.c,
+      face1_s7.a, face1_s7.b, face1_s7.c,
+      face2_s7.a, face2_s7.b, face2_s7.c,
+      face4_s7.a, face4_s7.b, face4_s7.c,
+      face5_s7.a, face5_s7.b, face5_s7.c,
+      face3_s7.a, face3_s7.b, face3_s7.c
     ) 
     val normals = vtkBlock.normals
     val normalsDiff = doubleListElementDiff(expectedNormals, normals)

--- a/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/rockslicing/BlockVTKSpec.scala
@@ -14,6 +14,17 @@ class BlockVTKSpec extends FunSuite {
   )
   val unitCube = Block((0.0, 0.0, 0.0), boundingFaces)
 
+  val boundingFaces2 = List(
+    Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0), // -x <= 0
+    Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0),  // x <= 1
+    Face((0.0, -1.0, 0.0), 0.0, phi=0, cohesion=0), // -y <= 0
+    Face((0.0, 1.0, 0.0), 1.0, phi=0, cohesion=0),  // y <= 1
+    Face((0.0, 0.0, -1.0), 0.0, phi=0, cohesion=0), // -z <= 0
+    Face((0.0, 0.0, 1.0), 1.0, phi=0, cohesion=0),  // z <= 1
+    Face((0.707106781187, 0.707106781187, 0.0), 0.707106781187 - 0.5, phi=0, cohesion=0) // sqrt(2)*x + sqrt(2)*y <= 1
+  )
+  val sevenSidedBlock = Block((0.0, 0.0, 0.0), boundingFaces2)
+
   val face1 = Face((-1.0, 0.0, 0.0), 0.0, phi=0, cohesion=0)
   val face2 = Face((1.0, 0.0, 0.0), 1.0, phi=0, cohesion=0)
   val face3 = Face((0.0, -1.0, 0.0), 0.0, phi=0, cohesion=0)
@@ -47,6 +58,20 @@ class BlockVTKSpec extends FunSuite {
       face6 -> face6Verts
     )
     val vtkBlock = BlockVTK(unitCube)
+    assert(expectedVertices == vtkBlock.orientedVertices)
+  }
+
+  test("The vertices should be oriented counter-clockwise for each face (seven-sided block)") {
+    val expectedVertices = Map(
+      face1 -> face1Verts,
+      face2 -> face2Verts,
+      face3 -> face3Verts,
+      face4 -> face4Verts,
+      face5 -> face5Verts,
+      face6 -> face6Verts
+    )
+    val vtkBlock = BlockVTK(sevenSidedBlock)
+    println(vtkBlock.tupleVertices)
     assert(expectedVertices == vtkBlock.orientedVertices)
   }
 


### PR DESCRIPTION
Changed vertex calcs to exclude vertices that fall outside of the block. Made some minor changes to `vtkWriter.py` which fixed issues with non-cube block visualization.
