### PR TITLE
SeedJointSelector bug fix

### DIFF
--- a/src/main/scala/edu/berkeley/ce/sparkrocks/SeedJointSelector.scala
+++ b/src/main/scala/edu/berkeley/ce/sparkrocks/SeedJointSelector.scala
@@ -38,7 +38,7 @@ object SeedJointSelector {
       println(s"Average Volume: %.2f".format(avgVolume))
       println(s"Max volume: %.2f".format(volumes.max))
       println(s"Min volume: %.2f".format(volumes.min))
-      (partitionBlocks, leftOverJoints ++ jointSets.tail.flatten)
+      (partitionBlocks, leftOverJoints ++ jointSets.drop(jointSetSpan).flatten)
     } else {
       // Unable to find sufficient partitions, run with greater span
       generateSeedBlocks(jointSets, inputVolume, numPartitions, jointSetSpan + 1)
@@ -81,7 +81,8 @@ object SeedJointSelector {
       }
     } else {
       // Joint set non-persistent, check next one
-      findSeedBlocks(jointSets.tail, inputVolume, numPartitions, jointSetSpan, seedBlocks, remainingJoints)
+      findSeedBlocks(jointSets.tail, inputVolume, numPartitions, jointSetSpan, seedBlocks,
+        remainingJoints ++ jointSets.head)
     }
   }
 
@@ -155,7 +156,7 @@ object SeedJointSelector {
         val remainingVolume = jointOption.get
         if (remainingVolume.volume <= volumePerPiece) {
           // Remaining volume small enough, return
-          (selectedJoints :+ jointSet(0), remainingJoints)
+          (selectedJoints :+ jointSet(0), remainingJoints ++ jointSet.tail)
         } else {
           // Large volume still remains, keep cycling
           findSeedJoints(jointSet.tail, remainingVolume, totalVolume, volumePerPiece,
@@ -170,7 +171,7 @@ object SeedJointSelector {
         (selectedJoints, remainingJoints :+ jointSet(0))
       } else {
         // Joint intersects volume
-        (selectedJoints :+ jointSet.head, remainingJoints)
+        (selectedJoints :+ jointSet(0), remainingJoints)
       }
     } else {
       // Sufficiently subdivided

--- a/src/test/scala/edu/berkeley/ce/sparkrocks/SeedJointSelectorSpec.scala
+++ b/src/test/scala/edu/berkeley/ce/sparkrocks/SeedJointSelectorSpec.scala
@@ -187,7 +187,7 @@ class SeedJointSelectorSpec extends FunSuite {
     assert(seedBlocks.length >=4)
   }
 
-  test("Generate at least 8 partitions from multiple joint sets") {
+  test("Generate at least 8 partitions from two joint sets") {
     val globalOrigin = Array[Double](0.5, 0.5, 0.5)
     val boundingBox = (Array[Double](0.0, 0.0, 0.0), Array[Double](2.0, 2.0, 2.0))
     val rockVolume = Seq[InputFace](
@@ -211,7 +211,7 @@ class SeedJointSelectorSpec extends FunSuite {
     assert(seedBlocks.length >= 8)
   }
 
-  test("Select seed joints from multiple joint sets") {
+  test("Select seed joints from two joint sets") {
     val globalOrigin = Array[Double](0.5, 0.5, 0.5)
     val boundingBox = (Array[Double](0.0, 0.0, 0.0), Array[Double](2.0, 2.0, 2.0))
     val rockVolume = Seq[InputFace](


### PR DESCRIPTION
Fixes bug where joints that weren't selected as seed joints went missing. Also, addresses bug where duplicate joints were added to remaining joints when searching over multiple joint sets simultaneously.
