### PR TITLE
Fixes bug where blocks are lost when passing 'f' flag

### DIFF
--- a/src/main/scala/edu/berkeley/ce/sparkrocks/SeedJointSelector.scala
+++ b/src/main/scala/edu/berkeley/ce/sparkrocks/SeedJointSelector.scala
@@ -73,8 +73,14 @@ object SeedJointSelector {
       }
       if (partitioning.length < numPartitions) {
         // Insufficient partitions found
-        findSeedBlocks(jointSets.tail, inputVolume, numPartitions, jointSetSpan, partitioning,
-          remainingJoints ++ jointSets.head)
+        if (jointSetSpan == jointSets.length) {
+          // Joint span will exceed joint set length on next recursion
+          (partitioning, remainingJoints ++ leftOverJoints)
+        } else {
+          // Joint span won't exceed joint set length on next recursion
+          findSeedBlocks(jointSets.tail, inputVolume, numPartitions, jointSetSpan, partitioning,
+            remainingJoints ++ jointSets.head)
+        }
       } else {
         // Sufficient partitions, return
         (partitioning, remainingJoints ++ leftOverJoints)


### PR DESCRIPTION
Addresses issue where joints are dropped from joint sets when user passes `f` flag. This was causing less blocks to be generated without loss of actual volume.
